### PR TITLE
feat: set alterId to 0 by default

### DIFF
--- a/TMessagesProj/src/main/java/com/v2ray/ang/dto/AngConfig.kt
+++ b/TMessagesProj/src/main/java/com/v2ray/ang/dto/AngConfig.kt
@@ -16,7 +16,7 @@ data class AngConfig(
                          var address: String = "",
                          var port: Int = 443,
                          var id: String = "",
-                         var alterId: Int = 64,
+                         var alterId: Int = 0,
                          var security: String = "auto",
                          var network: String = "tcp",
                          var remarks: String = "",


### PR DESCRIPTION
VMess MD5 is deprecated now.