### PR TITLE
Add WAV support

### DIFF
--- a/TMessagesProj/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
+++ b/TMessagesProj/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
@@ -90,6 +90,9 @@ public final class FfmpegLibrary {
         return "flac";
       case MimeTypes.AUDIO_ALAC:
         return "alac";
+      case MimeTypes.AUDIO_WAV:
+      case MimeTypes.AUDIO_X_WAV:
+        return "wav";
       case MimeTypes.AUDIO_MLAW:
         return "pcm_mulaw";
       case MimeTypes.AUDIO_ALAW:

--- a/TMessagesProj/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecInfo.java
+++ b/TMessagesProj/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecInfo.java
@@ -519,6 +519,8 @@ public final class MediaCodecInfo {
         || MimeTypes.AUDIO_FLAC.equals(mimeType)
         || MimeTypes.AUDIO_ALAW.equals(mimeType)
         || MimeTypes.AUDIO_MLAW.equals(mimeType)
+        || MimeTypes.AUDIO_WAV.equals(mimeType)
+        || MimeTypes.AUDIO_X_WAV.equals(mimeType)
         || MimeTypes.AUDIO_MSGSM.equals(mimeType)) {
       // Platform code should have set a default.
       return maxChannelCount;

--- a/TMessagesProj/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
+++ b/TMessagesProj/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
@@ -70,6 +70,8 @@ public final class MimeTypes {
   public static final String AUDIO_FLAC = BASE_TYPE_AUDIO + "/flac";
   public static final String AUDIO_ALAC = BASE_TYPE_AUDIO + "/alac";
   public static final String AUDIO_MSGSM = BASE_TYPE_AUDIO + "/gsm";
+  public static final String AUDIO_WAV = BASE_TYPE_AUDIO + "/wav";
+  public static final String AUDIO_X_WAV = BASE_TYPE_AUDIO + "/x-wav";
   public static final String AUDIO_UNKNOWN = BASE_TYPE_AUDIO + "/x-unknown";
 
   public static final String TEXT_VTT = BASE_TYPE_TEXT + "/vtt";

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -4859,7 +4859,7 @@ public class MessageObject {
             }
             if (!TextUtils.isEmpty(document.mime_type)) {
                 String mime = document.mime_type.toLowerCase();
-                if (mime.equals("audio/flac") || mime.equals("audio/ogg") || mime.equals("audio/opus") || mime.equals("audio/x-opus+ogg")) {
+                if (mime.equals("audio/flac") || mime.equals("audio/ogg") || mime.equals("audio/opus") || mime.equals("audio/x-opus+ogg") || mime.equals("audio/wav") || mime.equals("audio/x-wav")) {
                     return true;
                 } else if (mime.equals("application/octet-stream") && FileLoader.getDocumentFileName(document).endsWith(".opus")) {
                     return true;


### PR DESCRIPTION
Nekogram X(and probably all other Telegram clients) cant play WAV audio files(WAV files are recognized as documents, not as audio files), this patch adds a bit of code to add support for playing WAV files.