### PR TITLE
feat: hideGroupSticker

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -3328,7 +3328,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
             }
             stickerSets.add(pack);
         }
-        if (info != null) {
+        if (info != null && (!NekoConfig.hideGroupSticker)) {
             long hiddenStickerSetId = MessagesController.getEmojiSettings(currentAccount).getLong("group_hide_stickers_" + info.id, -1);
             TLRPC.Chat chat = MessagesController.getInstance(currentAccount).getChat(info.id);
             if (chat == null || info.stickerset == null || !ChatObject.hasAdminRights(chat)) {
@@ -3370,8 +3370,8 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     stickerSets.remove(0);
                     a--;
                 } else {
-                    hasChatStickers = true;
-                    stickersTab.addStickerTab(chat);
+                        hasChatStickers = true;
+                        stickersTab.addStickerTab(chat);
                 }
             } else {
                 TLRPC.TL_messages_stickerSet stickerSet = stickerSets.get(a);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -149,6 +149,7 @@ public class NekoConfig {
     public static boolean disableTrending;
     public static boolean dontSendGreetingSticker;
     public static boolean hideTimeForSticker;
+    public static boolean hideGroupSticker;
     public static boolean takeGIFasVideo;
     public static int maxRecentStickerCount;
     public static boolean disableSwipeToNext;
@@ -325,6 +326,7 @@ public class NekoConfig {
         disableTrending = preferences.getBoolean("disableTrending", true);
         dontSendGreetingSticker = preferences.getBoolean("dontSendGreetingSticker", false);
         hideTimeForSticker = preferences.getBoolean("hideTimeForSticker", false);
+        hideGroupSticker = preferences.getBoolean("hideGroupSticker", false);
         takeGIFasVideo = preferences.getBoolean("takeGIFasVideo", false);
         maxRecentStickerCount = preferences.getInt("maxRecentStickerCount", 20);
         disableSwipeToNext = preferences.getBoolean("disableSwipeToNext", true);
@@ -833,6 +835,10 @@ public class NekoConfig {
 
     public static void toggleHideTimeForSticker() {
         preferences.edit().putBoolean("hideTimeForSticker", hideTimeForSticker = !hideTimeForSticker).apply();
+    }
+
+    public static void toggleHideGroupSticker() {
+        preferences.edit().putBoolean("hideGroupSticker", hideGroupSticker = !hideGroupSticker).apply();
     }
 
     public static void toggleTakeGIFasVideo() {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -79,6 +79,7 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
     private int disableTrendingRow;
     private int dontSendGreetingStickerRow;
     private int hideTimeForStickerRow;
+    private int hideGroupStickerRow;
     private int takeGIFasVideoRow;
     private int maxRecentStickerCountRow;
     private int disableSwipeToNextRow;
@@ -289,6 +290,11 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                 if (view instanceof TextCheckCell) {
                     ((TextCheckCell) view).setChecked(NekoConfig.hideTimeForSticker);
                 }
+            } else if (position == hideGroupStickerRow) {
+                NekoConfig.toggleHideGroupSticker();
+                if (view instanceof TextCheckCell) {
+                    ((TextCheckCell) view).setChecked(NekoConfig.hideGroupSticker);
+                }
             } else if (position == takeGIFasVideoRow) {
                 NekoConfig.toggleTakeGIFasVideo();
                 if (view instanceof TextCheckCell) {
@@ -375,6 +381,7 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
         disableTrendingRow = rowCount++;
         dontSendGreetingStickerRow = rowCount++;
         hideTimeForStickerRow = rowCount++;
+        hideGroupStickerRow = rowCount++;
         takeGIFasVideoRow = rowCount++;
         maxRecentStickerCountRow = rowCount++;
         disableSwipeToNextRow = rowCount++;
@@ -741,6 +748,8 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                         textCell.setTextAndCheck(LocaleController.getString("DisableTrending", R.string.DisableTrending), NekoConfig.disableTrending, true);
                     } else if (position == dontSendGreetingStickerRow) {
                         textCell.setTextAndCheck(LocaleController.getString("DontSendGreetingSticker", R.string.DontSendGreetingSticker), NekoConfig.dontSendGreetingSticker, true);
+                    } else if (position == hideGroupStickerRow) {
+                        textCell.setTextAndCheck(LocaleController.getString("HideGroupSticker", R.string.HideGroupSticker), NekoConfig.hideGroupSticker, true);
                     } else if (position == hideTimeForStickerRow) {
                         textCell.setTextAndCheck(LocaleController.getString("HideTimeForSticker", R.string.HideTimeForSticker), NekoConfig.hideTimeForSticker, true);
                     } else if (position == takeGIFasVideoRow) {

--- a/TMessagesProj/src/main/res/values/strings_neko.xml
+++ b/TMessagesProj/src/main/res/values/strings_neko.xml
@@ -114,6 +114,7 @@
     <string name="TakeGIFasVideo">Take GIF as video</string>
     <string name="UseMediaStreamInVoip">Use media stream in VoIP</string>
     <string name="HideTimeForSticker">Hide time for stickers</string>
+    <string name="HideGroupSticker">Hide group sticker</string>
     <string name="useSystemDNS">Use system DNS</string>
     <string name="customDoH">Custom DoH</string>
     <string name="customGroupVoipAudioBitrate">Group VoIP Audio Bitrate</string>


### PR DESCRIPTION
this feature is to hide the group sticker set by the group admins and make the sticker package added by the user appear at the top.
when this feature is enabled, group sticker will be hidden
default setting is false.

tested on my personal device

Signed-off-by: qwq233 <qwq233@qwq2333.top>