### PR TITLE
Switch order of nameOrder strings

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -153,8 +153,8 @@ public class NekoGeneralSettingsActivity extends BaseFragment {
     private final NekomuraTGCell disableNumberRoundingRow = addNekomuraTGCell(nkmrCells.new NekomuraTGTextCheck(NekomuraConfig.disableNumberRounding, "4.8K -> 4777"));
     private final NekomuraTGCell openArchiveOnPullRow = addNekomuraTGCell(nkmrCells.new NekomuraTGTextCheck(NekomuraConfig.openArchiveOnPull));
     private final NekomuraTGCell nameOrderRow = addNekomuraTGCell(nkmrCells.new NekomuraTGSelectBox(null, NekomuraConfig.nameOrder, new String[]{
-            LocaleController.getString("FirstLast", R.string.FirstLast),
-            LocaleController.getString("LastFirst", R.string.LastFirst)
+            LocaleController.getString("LastFirst", R.string.LastFirst),
+            LocaleController.getString("FirstLast", R.string.FirstLast)
     }, null));
     private final NekomuraTGCell usePersianCalendarRow = addNekomuraTGCell(nkmrCells.new NekomuraTGTextCheck(NekomuraConfig.usePersianCalendar, LocaleController.getString("UsePersiancalendarInfo")));
     private final NekomuraTGCell displayPersianCalendarByLatinRow = addNekomuraTGCell(nkmrCells.new NekomuraTGTextCheck(NekomuraConfig.displayPersianCalendarByLatin));


### PR DESCRIPTION
Currently in `Neko Settings > General > Name order`, the `Last First` switch displays names in First name Last name order, and the `First Last` switch displays names in Last name First name order.

Cause:
In https://github.com/NekoX-Dev/NekoX/blob/main/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java#L2644, names are displayed in First name Last name order if `NekomuraConfig.nameOrder.Int() == 1`, else it will be Last name First name order.
The string array has index 0 for `FirstLast` and index 1 for `LastFirst', causing the opposite string to be used.

This fixes it.