### PR TITLE
Correction of Error in PGP Signature Functions 

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -3589,7 +3589,7 @@ public class ChatActivityEnterView extends FrameLayout implements NotificationCe
         Intent intent = new Intent();
 
         if (NekomuraConfig.openPGPKeyId.Long() != 0L && save)
-            intent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, NekomuraConfig.openPGPKeyId.Bool());
+            intent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, NekomuraConfig.openPGPKeyId.Long());
 
         signComment(intent, save);
 


### PR DESCRIPTION
I found a typo in the PGP message signature button code.
The location in order to transfer the key to OpenPGPAPI, your code transmits boolean value.
This in some scenarios causes the destruction of the application. 