### PR TITLE
ShareMyKey in private chats

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -19148,7 +19148,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         }
 
         if (shareKeyItem != null) {
-            if (currentChat != null && ChatObject.canSendMessages(currentChat) && StrUtil.isNotBlank(NekomuraConfig.openPGPApp.String())) {
+            if ((currentChat != null && ChatObject.canSendMessages(currentChat) || user != null && !user.self) && StrUtil.isNotBlank(NekomuraConfig.openPGPApp.String())) {
                 shareKeyItem.setVisibility(View.VISIBLE);
             } else {
                 shareKeyItem.setVisibility(View.GONE);


### PR DESCRIPTION
Added the ability to share the public pgp key in private dialogs.
Previously, this was only possible in public chats.

P.S. there was a request for this function from a user in the official chat.