### PR TITLE
Add fdroidRelease build type

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -248,15 +248,21 @@ android {
         fdroidRelease {
             initWith foss
             matchingFallbacks = ["release", "debug"]
+
+            splits {
+                abi {
+                    enable true
+                }
+            }
         }
 
         fdroidArmRelease {
-            initWith foss
+            initWith fdroidRelease
             matchingFallbacks = ["release", "debug"]
         }
 
         fdroidArm64Release {
-            initWith foss
+            initWith fdroidRelease
             matchingFallbacks = ["release", "debug"]
         }
     }

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -245,6 +245,11 @@ android {
             matchingFallbacks = ["release", "debug"]
         }
 
+        fdroidRelease {
+            initWith foss
+            matchingFallbacks = ["release", "debug"]
+        }
+
         fdroidArmRelease {
             initWith foss
             matchingFallbacks = ["release", "debug"]

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -91,11 +91,6 @@ android {
 
             if (targetTask.contains("fdroid")) {
                 enable = false
-                universalApk true
-
-                // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
-                reset()
-                include "armeabi-v7a", "arm64-v8a"
             } else {
                 enable = true
                 universalApk = false
@@ -257,9 +252,6 @@ android {
         fdroidRelease {
             initWith foss
             matchingFallbacks = ["release", "debug"]
-
-            // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
-            ndk.abiFilters "armeabi-v7a", "arm64-v8a"
         }
     }
 

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -91,6 +91,10 @@ android {
 
             if (targetTask.contains("fdroid")) {
                 enable = false
+
+                // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
+                reset()
+                include "armeabi-v7a", "arm64-v8a"
             } else {
                 enable = true
                 universalApk = false
@@ -345,15 +349,6 @@ android {
 
     applicationVariants.all { variant ->
         def flavor = variant.mergedFlavor
-        if (variant.buildType.name == "fdroidArmRelease") {
-            variant.outputs.each { output ->
-                output.versionNameOverride = flavor.versionName + "-arm"
-            }
-        } else if (variant.buildType.name == "fdroidArm64Release") {
-            variant.outputs.each { output ->
-                output.versionNameOverride = flavor.versionName + "-arm64"
-            }
-        }
         variant.outputs.all { output ->
             outputFileName = outputFileName.replace("TMessagesProj", "NekoX")
         }

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -89,11 +89,11 @@ android {
 
         abi {
 
-            if (requireFlavor().startsWith("Fdroid")) {
-                isEnable = false
+            if (targetTask.contains("fdroid")) {
+                enable = false
             } else {
-                isEnable = true
-                isUniversalApk = false
+                enable = true
+                universalApk = false
 
                 if (!targetAbi.isBlank()) {
                     reset()
@@ -298,20 +298,12 @@ android {
             }
         }
 
-        fdroidArmRelease {
+        fdroidRelease {
             jni {
                 srcDirs = ["./jni/"]
             }
             jniLibs.srcDirs = []
         }
-
-        fdroidArm64Release {
-            jni {
-                srcDirs = ["./jni/"]
-            }
-            jniLibs.srcDirs = []
-        }
-
     }
 
     flavorDimensions "version"

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -91,6 +91,7 @@ android {
 
             if (targetTask.contains("fdroid")) {
                 enable = false
+                universalApk true
 
                 // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
                 reset()

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -89,19 +89,23 @@ android {
 
         abi {
 
-            enable true
-            universalApk false
+            if (requireFlavor().startsWith("Fdroid")) {
+                isEnable = false
+            } else {
+                isEnable = true
+                isUniversalApk = false
 
-            if (!targetAbi.isBlank()) {
-                reset()
-                if (targetAbi == "arm64") {
-                    include "arm64-v8a"
-                } else if (targetAbi == "arm") {
-                    include "armeabi-v7a"
+                if (!targetAbi.isBlank()) {
+                    reset()
+                    if (targetAbi == "arm64") {
+                        include "arm64-v8a"
+                    } else if (targetAbi == "arm") {
+                        include "armeabi-v7a"
+                    }
+                } else if (!nativeTarget.isBlank()) {
+                    reset()
+                    include nativeTarget
                 }
-            } else if (!nativeTarget.isBlank()) {
-                reset()
-                include nativeTarget
             }
         }
 
@@ -247,24 +251,6 @@ android {
 
         fdroidRelease {
             initWith foss
-            matchingFallbacks = ["release", "debug"]
-
-            splits {
-                abi {
-                    enable false
-                    reset()
-                    include "armeabi-v7a", "arm64-v8a"
-                }
-            }
-        }
-
-        fdroidArmRelease {
-            initWith fdroidRelease
-            matchingFallbacks = ["release", "debug"]
-        }
-
-        fdroidArm64Release {
-            initWith fdroidRelease
             matchingFallbacks = ["release", "debug"]
         }
     }

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -91,6 +91,10 @@ android {
 
             if (targetTask.contains("fdroid")) {
                 enable = false
+
+                // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
+                reset()
+                include "armeabi-v7a", "arm64-v8a"
             } else {
                 enable = true
                 universalApk = false

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -91,10 +91,6 @@ android {
 
             if (targetTask.contains("fdroid")) {
                 enable = false
-
-                // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
-                reset()
-                include "armeabi-v7a", "arm64-v8a"
             } else {
                 enable = true
                 universalApk = false
@@ -256,6 +252,9 @@ android {
         fdroidRelease {
             initWith foss
             matchingFallbacks = ["release", "debug"]
+
+            // Only build the arm versions before https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/516 is solved
+            ndk.abiFilters "armeabi-v7a", "arm64-v8a"
         }
     }
 

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -251,7 +251,9 @@ android {
 
             splits {
                 abi {
-                    enable true
+                    enable false
+                    reset()
+                    include "armeabi-v7a", "arm64-v8a"
                 }
             }
         }


### PR DESCRIPTION
Since we (fdroid) don't have much capacity to manually update apps, and I've observed that you are not updating NekoX in fdroid manually actively, it's reasonable to enable full auto update by providing a universal APK