### PR TITLE
Share a message in another app 

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -303,6 +303,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
     private final static int nkbtn_hide = 2009;
     private final static int nkbtn_savemessage = 2010;
     private final static int nkbtn_forward_noquote = 2011;
+    private final static int nkbtn_sharemessage = 2030;
 
     // chat click menu buttons
     private final static int nkbtn_detail = 2012;
@@ -2865,6 +2866,8 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         }
 
         actionModeOtherItem.addSubItem(nkbtn_translate, R.drawable.ic_translate, LocaleController.getString("Translate", R.string.Translate));
+        if (NekomuraConfig.showShareMessages.Bool()) 
+            actionModeOtherItem.addSubItem(nkbtn_sharemessage, R.drawable.baseline_share_24, LocaleController.getString("ShareMessages", R.string.ShareMessages));
         actionModeOtherItem.addSubItem(nkbtn_unpin, R.drawable.deproko_baseline_pin_undo_24, LocaleController.getString("UnpinMessage", R.string.UnpinMessage));
         if (!noforward)
             actionModeOtherItem.addSubItem(nkbtn_savemessage, R.drawable.baseline_bookmark_24, LocaleController.getString("AddToSavedMessages", R.string.AddToSavedMessages));
@@ -13347,6 +13350,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 }
 
                 actionModeOtherItem.setSubItemVisibility(nkbtn_translate, selectedMessagesCanCopyIds[0].size() + selectedMessagesCanCopyIds[1].size() > 0);
+                actionModeOtherItem.setSubItemVisibility(nkbtn_sharemessage, selectedMessagesCanCopyIds[0].size() + selectedMessagesCanCopyIds[1].size() > 0);
 
                 boolean allowPin = false;
                 if (currentChat != null) {
@@ -20891,6 +20895,13 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                                     icons.add(R.drawable.ic_translate);
                                 }
                             }
+                            if (NekomuraConfig.showShareMessages.Bool()) {
+                                if (messageObject != null || docsWithMessages) {
+                                    items.add(LocaleController.getString("ShareMessages", R.string.ShareMessages));
+                                    options.add(nkbtn_sharemessage);
+                                    icons.add(R.drawable.baseline_share_24);
+                                }
+                            }
                             if (messageObject != null && StrUtil.isNotBlank(messageObject.messageOwner.message) && StrUtil.isNotBlank(NekomuraConfig.openPGPApp.String())) {
                                 if (PgpHelper.PGP_CLEARTEXT_SIGNATURE.matcher(selectedObject.messageOwner.message).matches()) {
                                     items.add(LocaleController.getString("PGPVerify", R.string.PGPVerify));
@@ -27405,6 +27416,8 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             ArrayList<MessageObject> messages = getSelectedMessages();
             forwardMessages(messages, false, true, 0, UserConfig.getInstance(currentAccount).getClientUserId());
             undoView.showWithAction(getUserConfig().getClientUserId(), UndoView.ACTION_FWD_MESSAGES, messages.size());
+        } else if (id == nkbtn_sharemessage) {
+            //AlertUtil.showToast("nkbtn_onclick_actionbar");
         } else if (id == nkbtn_hide) {
             ArrayList<MessageObject> messages = getSelectedMessages();
             for (MessageObject message : messages) {
@@ -27646,6 +27659,30 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 }
                 forwardMessages(messages, false, true, 0, getUserConfig().getClientUserId());
                 undoView.showWithAction(getUserConfig().getClientUserId(), UndoView.ACTION_FWD_MESSAGES, messages.size());
+                break;
+            }
+            case nkbtn_sharemessage: {
+                //AlertUtil.showToast("nkbtn_onclick");
+                MessageObject messageObject = null;
+                if (selectedObjectGroup != null) {
+                    if (!TextUtils.isEmpty(selectedObjectGroup.messages.get(0).messageOwner.message)) {
+                        messageObject = selectedObjectGroup.messages.get(0);
+                    }
+                } else if (!TextUtils.isEmpty(selectedObject.messageOwner.message) || selectedObject.type == MessageObject.TYPE_POLL) {
+                    messageObject = selectedObject;
+                }
+                if (messageObject == null) {
+                    return;
+                }
+                Intent intent = new Intent(Intent.ACTION_SEND);
+                intent.setType("text/plain");
+                String body = messageObject.messageOwner.message;
+                intent.putExtra(Intent.EXTRA_TEXT,body);
+                try {
+                    getParentActivity().startActivity(intent);
+                } catch (Exception e) {
+                    AlertUtil.showToast(e);
+                }
                 break;
             }
             case nkbtn_stickerdl: {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -27416,8 +27416,6 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             ArrayList<MessageObject> messages = getSelectedMessages();
             forwardMessages(messages, false, true, 0, UserConfig.getInstance(currentAccount).getClientUserId());
             undoView.showWithAction(getUserConfig().getClientUserId(), UndoView.ACTION_FWD_MESSAGES, messages.size());
-        } else if (id == nkbtn_sharemessage) {
-            //AlertUtil.showToast("nkbtn_onclick_actionbar");
         } else if (id == nkbtn_hide) {
             ArrayList<MessageObject> messages = getSelectedMessages();
             for (MessageObject message : messages) {
@@ -27662,7 +27660,6 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 break;
             }
             case nkbtn_sharemessage: {
-                //AlertUtil.showToast("nkbtn_onclick");
                 MessageObject messageObject = null;
                 if (selectedObjectGroup != null) {
                     if (!TextUtils.isEmpty(selectedObjectGroup.messages.get(0).messageOwner.message)) {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -316,7 +316,7 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
         linearLayoutInviteContainer.setOrientation(LinearLayout.VERTICAL);
         linearLayout.addView(linearLayoutInviteContainer, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
 
-        int count = NekoXConfig.developerMode ? 10 : 9;
+        int count = NekoXConfig.developerMode ? 11 : 10;
         for (int a = 0; a < count; a++) {
             TextCheckCell textCell = new TextCheckCell(context);
             switch (a) {
@@ -357,6 +357,10 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                     break;
                 }
                 case 9: {
+                    textCell.setTextAndCheck(LocaleController.getString("ShareMessages", R.string.ShareMessages), NekomuraConfig.showShareMessages.Bool(), false);
+                    break;
+                }
+                case 10: {
                     textCell.setTextAndCheck(LocaleController.getString("MessageDetails", R.string.MessageDetails), NekomuraConfig.showMessageDetails.Bool(), false);
                     break;
                 }
@@ -404,9 +408,14 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                         break;
                     }
                     case 9: {
+                        textCell.setChecked(NekomuraConfig.showShareMessages.toggleConfigBool());
+                        break;
+                    }
+                    case 10: {
                         textCell.setChecked(NekomuraConfig.showMessageDetails.toggleConfigBool());
                         break;
                     }
+
                 }
             });
         }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -415,7 +415,6 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                         textCell.setChecked(NekomuraConfig.showMessageDetails.toggleConfigBool());
                         break;
                     }
-
                 }
             });
         }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nkmr/NekomuraConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nkmr/NekomuraConfig.java
@@ -74,6 +74,7 @@ public class NekomuraConfig {
     public static ConfigItem showMessageDetails = addConfig("showMessageDetails", configTypeBool, false);
     public static ConfigItem showTranslate = addConfig("showTranslate", configTypeBool, true);
     public static ConfigItem showRepeat = addConfig("showRepeat", configTypeBool, false);
+    public static ConfigItem showShareMessages = addConfig("showShareMessages", configTypeBool, false);
     public static ConfigItem showMessageHide = addConfig("showMessageHide", configTypeBool, false);
 
     public static ConfigItem eventType = addConfig("eventType", configTypeInt, 0);
@@ -346,6 +347,8 @@ public class NekomuraConfig {
             showTranslate.setConfigBool(preferences.getBoolean("showTranslate", true));
         if (preferences.contains("showRepeat"))
             showRepeat.setConfigBool(preferences.getBoolean("showRepeat", false));
+        if (preferences.contains("showShareMessages"))
+            showShareMessages.setConfigBool(preferences.getBoolean("showShareMessages", false));
         if (preferences.contains("showMessageHide"))
             showMessageHide.setConfigBool(preferences.getBoolean("showMessageHide", false));
 

--- a/TMessagesProj/src/main/res/values-ru/strings_nekox.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings_nekox.xml
@@ -182,6 +182,7 @@
     <string name="PGPImport">Импорт открытого ключа</string>
     <string name="PGPImportPrivate">Импорт закрытого ключа</string>
     <string name="ShareMyKey">Отправить открытый ключ</string>
+    <string name="ShareMessages">Поделиться</string>
     <string name="DisableVibration">Отключить вибрацию</string>
     <string name="IgnoreContentRestrictions">Игнорировать ограничения контента</string>
     <string name="IgnoreContentRestrictionsNotice">Разрешает отображение сообщений, недоступных для показа на Android.</string>

--- a/TMessagesProj/src/main/res/values/strings_nekox.xml
+++ b/TMessagesProj/src/main/res/values/strings_nekox.xml
@@ -181,6 +181,7 @@
     <string name="PGPImport">Import Public Key</string>
     <string name="PGPImportPrivate">Import Private Key</string>
     <string name="ShareMyKey">Share My Public Key</string>
+    <string name="ShareMessages">Share</string>
     <string name="DisableVibration">Disable Vibration</string>
     <string name="IgnoreContentRestrictions">Ignore content restrictions</string>
     <string name="IgnoreContentRestrictionsNotice">Ignores play restrictions on messages.</string>


### PR DESCRIPTION
Added a function that allows you to `share` a message from telegram to another application.
Implemented using the standard android `Share Intent` mechanism.
My use case:
- transfer message text to notes
- send the text of the message to the TTS service, for reading out by voice

By default, the function is disabled in the nekox settings. 

![Screenshot_20211216-123849_Nekogram_X](https://user-images.githubusercontent.com/50487552/146328675-bc95e074-4510-426e-9ffb-0a3299145047.png)

