### PR TITLE
Disable "reactions" in the message menu 

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -21977,7 +21977,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             // NekoX: Merge 8.4.1, remove showMessageSeen here
 
             ReactionsContainerLayout reactionsLayout = new ReactionsContainerLayout(contentView.getContext(), currentAccount, getResourceProvider());
-            if (isReactionsAvailable) {
+            if (NekoConfig.ShowReactions.Bool() && isReactionsAvailable) {
                 int pad = 22;
                 int sPad = 24;
                 reactionsLayout.setPadding(AndroidUtilities.dp(4) + (LocaleController.isRTL ? 0 : sPad), AndroidUtilities.dp(4), AndroidUtilities.dp(4) + (LocaleController.isRTL ? sPad : 0), AndroidUtilities.dp(pad));

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -68,6 +68,7 @@ public class NekoConfig {
     public static ConfigItem showRepeat = addConfig("showRepeat", configTypeBool, false);
     public static ConfigItem showShareMessages = addConfig("showShareMessages", configTypeBool, false);
     public static ConfigItem showMessageHide = addConfig("showMessageHide", configTypeBool, false);
+    public static ConfigItem ShowReactions = addConfig("ShowReactions", configTypeBool, true);
 
     public static ConfigItem eventType = addConfig("eventType", configTypeInt, 0);
     public static ConfigItem actionBarDecoration = addConfig("ActionBarDecoration", configTypeInt, 0);
@@ -283,6 +284,8 @@ public class NekoConfig {
             showShareMessages.setConfigBool(preferences.getBoolean("showShareMessages", false));
         if (preferences.contains("showMessageHide"))
             showMessageHide.setConfigBool(preferences.getBoolean("showMessageHide", false));
+        if (preferences.contains("ShowReactions"))
+            ShowReactions.setConfigBool(preferences.getBoolean("ShowReactions", true));
 
         if (preferences.contains("eventType"))
             eventType.setConfigInt(preferences.getInt("eventType", 0));

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -318,7 +318,7 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
         linearLayoutInviteContainer.setOrientation(LinearLayout.VERTICAL);
         linearLayout.addView(linearLayoutInviteContainer, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
 
-        int count = NekoXConfig.developerMode ? 11 : 10;
+        int count = NekoXConfig.developerMode ? 12 : 11;
         for (int a = 0; a < count; a++) {
             TextCheckCell textCell = new TextCheckCell(context);
             switch (a) {
@@ -364,6 +364,10 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                 }
                 case 10: {
                     textCell.setTextAndCheck(LocaleController.getString("MessageDetails", R.string.MessageDetails), NekoConfig.showMessageDetails.Bool(), false);
+                    break;
+                }
+                case 11: {
+                    textCell.setTextAndCheck(LocaleController.getString("ShowReactions", R.string.ShowReactions), NekoConfig.ShowReactions.Bool(), false);
                     break;
                 }
             }
@@ -415,6 +419,10 @@ public class NekoChatSettingsActivity extends BaseFragment implements Notificati
                     }
                     case 10: {
                         textCell.setChecked(NekoConfig.showMessageDetails.toggleConfigBool());
+                        break;
+                    }
+                    case 11: {
+                        textCell.setChecked(NekoConfig.ShowReactions.toggleConfigBool());
                         break;
                     }
                 }

--- a/TMessagesProj/src/main/res/values/strings_nekox.xml
+++ b/TMessagesProj/src/main/res/values/strings_nekox.xml
@@ -263,4 +263,5 @@
     <string name="rememberAllBackMessages">Remember all clicked replies</string>
     <string name="DisableInstantCamera">Disable instant camera</string>
     <string name="showSeconds">Show timestamp in seconds</string>
+    <string name="ShowReactions">Show reactions</string>
 </resources>


### PR DESCRIPTION
Added the ability to disable `reaction` from the message menu.
This PR closes #718.

P.S. Now disabling the display `reactionsLayout`. I believe that it is possible to make a complete shutdown, but it is fraught with consequences. 

Example:
![photo_2022-01-20_22-55-45 (2)](https://user-images.githubusercontent.com/50487552/150396749-13014526-2b55-48f2-9188-f5ec66c4e105.jpg)
![photo_2022-01-20_22-55-45](https://user-images.githubusercontent.com/50487552/150396743-fd5dfa37-b237-44c0-b197-87ffff3f3180.jpg)

