### PR TITLE
Fix WS Relay payload input type

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/proxy/WsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/proxy/WsSettingsActivity.java
@@ -238,7 +238,7 @@ public class WsSettingsActivity extends BaseFragment {
                     break;
                 case 1:
                     payloadField = cursor;
-                    cursor.setInputType(InputType.TYPE_CLASS_NUMBER);
+                    cursor.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
                     cursor.setHintText(LocaleController.getString("WsPayload", R.string.WsPayload));
                     cursor.setText(currentBean.getPayloadStr());
                     break;


### PR DESCRIPTION
WS Relay payload is a Base64 string but input type was numeric. This commit fixes this bug.

Currently I don't have enough powerful workstation to test this change so if someone does this, I'll be very grateful.