### PR TITLE
WS Relay payload type fix

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/proxy/WsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/proxy/WsSettingsActivity.java
@@ -238,7 +238,7 @@ public class WsSettingsActivity extends BaseFragment {
                     break;
                 case 1:
                     payloadField = cursor;
-                    cursor.setInputType(InputType.TYPE_CLASS_NUMBER);
+                    cursor.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
                     cursor.setHintText(LocaleController.getString("WsPayload", R.string.WsPayload));
                     cursor.setText(currentBean.getPayloadStr());
                     break;


### PR DESCRIPTION
Payload should be Base64 string, not a number.
![Screenshot_20220314-125245_Nekogram X](https://user-images.githubusercontent.com/100516800/158167644-94105280-5c63-4143-bd8a-1cb689c97e3b.png)
![Screenshot_20220314-125301_Nekogram X](https://user-images.githubusercontent.com/100516800/158167709-150efcee-e67b-4df1-af19-e1ce100d300e.png)
