### PR TITLE
Fix video path

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -269,6 +269,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14652,6 +14653,29 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                     if (videoPath == null) {
                         showAttachmentError();
                     }
+                    File f = new File(videoPath);
+                    if (!f.canRead()) {
+                        // When the video file is located in a protected directory, and NekoX doesn't have the access permission to this directory, i.e. EACCES (Permission denied),
+                        //    copy it to the private temp directory
+                        FileLog.e("Failed to read input file " + videoPath + ", copy to private directory");
+                        try {
+                            final File file = AndroidUtilities.generateVideoPath();
+                            InputStream in = ApplicationLoader.applicationContext.getContentResolver().openInputStream(uri);
+                            FileOutputStream fos = new FileOutputStream(file);
+                            byte[] buffer = new byte[8 * 1024];
+                            int lengthRead;
+                            while ((lengthRead = in.read(buffer)) > 0) {
+                                fos.write(buffer, 0, lengthRead);
+                                fos.flush();
+                            }
+                            in.close();
+                            fos.close();
+                            videoPath = file.getAbsolutePath();
+                        } catch (Exception ex) {
+                            FileLog.e(ex);
+                            showAttachmentError();
+                        }
+                    }
                     if (paused) {
                         startVideoEdit = videoPath;
                     } else {
@@ -14664,8 +14688,13 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                             SendMessagesHelper.prepareSendingPhoto(getAccountInstance(), null, uri, dialog_id, replyingMessageObject, getThreadMessage(), null, null, null, null, 0, editingMessageObject, notify, scheduleDate);
                         }, themeDelegate);
                     } else {
-                        fillEditingMediaWithCaption(null, null);
-                        SendMessagesHelper.prepareSendingPhoto(getAccountInstance(), null, uri, dialog_id, replyingMessageObject, getThreadMessage(), null, null, null, null, 0, editingMessageObject, true, 0);
+                        ArrayList<SendMessagesHelper.SendingMediaInfo> photos = new ArrayList<>();
+                        SendMessagesHelper.SendingMediaInfo info = new SendMessagesHelper.SendingMediaInfo();
+                        info.uri = uri;
+                        photos.add(info);
+                        openPhotosEditor(photos, null);
+//                        fillEditingMediaWithCaption(null, null);
+//                        SendMessagesHelper.prepareSendingPhoto(getAccountInstance(), null, uri, dialog_id, replyingMessageObject, getThreadMessage(), null, null, null, null, 0, editingMessageObject, true, 0);
                     }
                 }
                 afterMessageSend();

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -14652,28 +14652,29 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                     }
                     if (videoPath == null) {
                         showAttachmentError();
-                    }
-                    File f = new File(videoPath);
-                    if (!f.canRead()) {
-                        // When the video file is located in a protected directory, and NekoX doesn't have the access permission to this directory, i.e. EACCES (Permission denied),
-                        //    copy it to the private temp directory
-                        FileLog.e("Failed to read input file " + videoPath + ", copy to private directory");
-                        try {
-                            final File file = AndroidUtilities.generateVideoPath();
-                            InputStream in = ApplicationLoader.applicationContext.getContentResolver().openInputStream(uri);
-                            FileOutputStream fos = new FileOutputStream(file);
-                            byte[] buffer = new byte[8 * 1024];
-                            int lengthRead;
-                            while ((lengthRead = in.read(buffer)) > 0) {
-                                fos.write(buffer, 0, lengthRead);
-                                fos.flush();
+                    } else {
+                        File f = new File(videoPath);
+                        if (!f.canRead()) {
+                            // When the video file is located in a protected directory, and NekoX doesn't have the access permission to this directory, i.e. EACCES (Permission denied),
+                            //    copy it to the private temp directory
+                            FileLog.e("Failed to read input file " + videoPath + ", copy to private directory");
+                            try {
+                                final File file = AndroidUtilities.generateVideoPath();
+                                InputStream in = ApplicationLoader.applicationContext.getContentResolver().openInputStream(uri);
+                                FileOutputStream fos = new FileOutputStream(file);
+                                byte[] buffer = new byte[8 * 1024];
+                                int lengthRead;
+                                while ((lengthRead = in.read(buffer)) > 0) {
+                                    fos.write(buffer, 0, lengthRead);
+                                    fos.flush();
+                                }
+                                in.close();
+                                fos.close();
+                                videoPath = file.getAbsolutePath();
+                            } catch (Exception ex) {
+                                FileLog.e(ex);
+                                showAttachmentError();
                             }
-                            in.close();
-                            fos.close();
-                            videoPath = file.getAbsolutePath();
-                        } catch (Exception ex) {
-                            FileLog.e(ex);
-                            showAttachmentError();
                         }
                     }
                     if (paused) {


### PR DESCRIPTION
When using the external file picker to choose videos, we may meet the black screen and `Caused by: java.io.FileNotFoundException, open failed: EACCES (Permission denied)` in logcat.

This exception will occur if the video file is located in private directory, or NekoX is not granted storage permission.

<details>
  <summary>Exceptions in Logcat</summary>

```log
2022-03-28 20:28:30.264 5321-5660/nekox.messenger E/ExoPlayerImplInternal: Source error
      com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:97)
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243)
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83)
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962)
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:923)
     Caused by: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:119)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88)
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at libcore.io.IoBridge.open(IoBridge.java:492)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:289)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:152)
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:108)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88) 
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: android.system.ErrnoException: open failed: EACCES (Permission denied)
        at libcore.io.Linux.open(Native Method)
        at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
        at libcore.io.BlockGuardOs.open(BlockGuardOs.java:254)
        at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
        at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7542)
        at libcore.io.IoBridge.open(IoBridge.java:478)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:289) 
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:152) 
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:108) 
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88) 
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
2022-03-28 20:28:30.265 5321-5321/nekox.messenger E/PhotoViewer$46: ExoPlaybackException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
    com.google.android.exoplayer2.ExoPlaybackException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at com.google.android.exoplayer2.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:394)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:223)
        at android.os.HandlerThread.run(HandlerThread.java:67)
     Caused by: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:97)
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243)
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83)
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962)
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:923)
     Caused by: com.google.android.exoplayer2.upstream.FileDataSource$FileDataSourceException: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:119)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88)
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: java.io.FileNotFoundException: /storage/emulated/0/Testvideo.mp4: open failed: EACCES (Permission denied)
        at libcore.io.IoBridge.open(IoBridge.java:492)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:289)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:152)
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:108)
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88) 
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
     Caused by: android.system.ErrnoException: open failed: EACCES (Permission denied)
        at libcore.io.Linux.open(Native Method)
        at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
        at libcore.io.BlockGuardOs.open(BlockGuardOs.java:254)
        at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
        at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7542)
        at libcore.io.IoBridge.open(IoBridge.java:478)
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:289) 
        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:152) 
        at com.google.android.exoplayer2.upstream.FileDataSource.openLocalFile(FileDataSource.java:108) 
        at com.google.android.exoplayer2.upstream.FileDataSource.open(FileDataSource.java:88) 
        at org.telegram.messenger.secretmedia.ExtendedDefaultDataSource.open(ExtendedDefaultDataSource.java:243) 
        at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:83) 
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:962) 
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:923) 
```

</details>

This pull request fixes this issue by copying the video file to NekoX's cache directory and override the `videoPath`.

```java
  File f = new File(videoPath);
  if (!f.canRead()) {
      FileLog.e("Failed to read input file " + videoPath + ", copy to private directory");
      // copy to the cache directory
  }
```
