### PR TITLE
fix issue #758

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -10537,6 +10537,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
 
                     boolean canPaint = newMessageObject.getDocument() == null || newMessageObject.canPreviewDocument() || newMessageObject.getMimeType().startsWith("video/");
                     paintButton.setVisibility(canPaint && canSendMediaToParentChatActivity() ? View.VISIBLE : View.GONE);
+                    shareButton.setVisibility(allowShare && shareItem.getVisibility() != View.VISIBLE ? View.VISIBLE : View.GONE);
                     bottomButtonsLayout.setVisibility(!videoPlayerControlVisible ? View.VISIBLE : View.GONE);
                     if (bottomButtonsLayout.getVisibility() == View.VISIBLE) {
                         menuItem.hideSubItem(gallery_menu_share);


### PR DESCRIPTION
This pull request fix the bug in https://github.com/NekoX-Dev/NekoX/issues/758.

**Reproduce steps:**

1. Tap a static image, and the share button (which in right bottom corner of screen) exists.
2. Tap to view a gif.
3. Tap the origin image again, and the share button doesn't disappear.