### PR TITLE
fix issue #558

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatActionCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatActionCell.java
@@ -489,6 +489,18 @@ public class ChatActionCell extends BaseCell implements DownloadController.FileD
                 }
             } else {
                 text = currentMessageObject.messageText;
+                //CS304 Issue link:https://github.com/NekoX-Dev/NekoX/issues/558
+                if (currentMessageObject.messageOwner != null) {
+                    if (currentMessageObject.messageOwner.action != null) {
+                        long date = currentMessageObject.messageOwner.date;
+                        String timestamp = LocaleController.getInstance().formatterDay.format(date * 1000);
+                        text += " · " + timestamp;
+                    } else if (currentMessageObject.currentEvent != null){
+                        long date = currentMessageObject.currentEvent.date;
+                        String timestamp = LocaleController.getInstance().formatterDay.format(date * 1000);
+                        text += " · " + timestamp;
+                    }
+                }
             }
         } else {
             text = customText;


### PR DESCRIPTION
This pull request fix the issue in https://github.com/NekoX-Dev/NekoX/issues/558.

**Reproduction steps**
1. The events which shown someone joined or left a group, or someone pinned a video, etc, in the main interface and the recent action interface will followed by a timestamp.